### PR TITLE
CI: Use 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ services:
   - docker
 
 dist: trusty
-sudo: false
 cache: bundler
 
 git:
@@ -23,7 +22,7 @@ jobs:
     - <<: *test
       rvm: 2.5.5
     - <<: *test
-      rvm: 2.4.5
+      rvm: 2.4.6
 
     - stage: coditsu
       language: ruby


### PR DESCRIPTION
This PR updates the CI matrix.

  - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration